### PR TITLE
Add support for linux

### DIFF
--- a/gosize.go
+++ b/gosize.go
@@ -120,7 +120,7 @@ func goPackageOfName(name string) string {
 	if name == "" {
 		return ""
 	}
-	if name[0] != '_' {
+	if name[0] != '_' && name[0] != '<' {
 		return ""
 	}
 	name = name[1:]


### PR DESCRIPTION
The linux objdump (at least on ubuntu) uses <> instead of _.
Example output from objdump -D on ubuntu - 0000000000402bf0 <runtime.c64hash>:

This way it works for compiled binaries on linux (checked on Ubuntu only) with CGO_ENABLE=1 and CGO_ENABLE=0